### PR TITLE
Revert "Fixed a year typo at the end of the README file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._


### PR DESCRIPTION
This reverts commit 7c4ed71a97d8675943a5630ed8ba6a696c70b46a.

Reverted fix for typo in readme file.